### PR TITLE
Adds Helsinki Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -3459,3 +3459,7 @@ https://github.com/theinfosecguy/QuickXSS
 ### BIDS Standard
 The [Brain Imaging Data Structure (BIDS)](https://bids.neuroimaging.io/) is an emerging standard for the organization of neuroimaging data.
 https://github.com/bids-standard/
+
+### Helsinki ruby
+Helsinki Ruby ry is a non-profit organisation that aims to promote Ruby and software engineering in general in Helsinki and Finland and beyond. We aim to put together events that aren’t available through commercial channels and to increase diversity and representation in tech.
+https://helsinkiruby.fi


### PR DESCRIPTION
## Helsinki Ruby

#### 1Password Teams URL

[helsinkiruby.1password.com](https://helsinkiruby.1password.com)

#### Project Name

Helsinki Ruby ry

#### Short Description

Helsinki Ruby ry is a registered non-profit organisation that aims to promote Ruby and software engineering in general in Helsinki and Finland and beyond. We aim to put together events that aren’t available through commercial channels and to increase diversity and representation in tech.

We organise Ruby meet-ups in Helsinki (https://rubybrigade.fi) and the occasional conference.

#### Project Age

2 years

#### Number Of Core Contributors

About 3 core organisers, >10 association members in total

#### Project Website

https://helsinkiruby.fi

#### Repository URL(s)

n/a or https://github.com/helsinkiruby

#### Latest Release URL(s)

n/a

#### License

n/a

## A Bit About Yourself

#### Name

Matias Korhonen

#### Email

matias@helsinkiruby.fi

#### Project Role

Chairman of the non-profit board

#### Profile/Website

https://matiaskorhonen.fi

#### Anything else to add?

#### Can we contact you?

We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [X] Yes, I'm open.
